### PR TITLE
feat: optimize mcp tool schemas

### DIFF
--- a/src/gating/schema-optimizer.ts
+++ b/src/gating/schema-optimizer.ts
@@ -1,0 +1,43 @@
+import type { MCPTool } from '../utils/types.js';
+
+const MAX_DESCRIPTION_LENGTH = 50;
+
+export function truncateDescription(description: string = ''): string {
+  return description.length > MAX_DESCRIPTION_LENGTH
+    ? description.slice(0, MAX_DESCRIPTION_LENGTH)
+    : description;
+}
+
+function optimizeSchema(schema: any): any {
+  if (Array.isArray(schema)) {
+    return schema.map(optimizeSchema);
+  }
+  if (schema && typeof schema === 'object') {
+    const optimized: any = {};
+    for (const [key, value] of Object.entries(schema)) {
+      if (key === 'examples' || key === 'default') {
+        continue;
+      }
+      if (key === 'description' && typeof value === 'string') {
+        optimized[key] = truncateDescription(value);
+        continue;
+      }
+      optimized[key] = optimizeSchema(value);
+    }
+    return optimized;
+  }
+  return schema;
+}
+
+export function optimizeTool(tool: MCPTool): MCPTool {
+  return {
+    ...tool,
+    description: truncateDescription(tool.description),
+    inputSchema: optimizeSchema(tool.inputSchema),
+  };
+}
+
+export default {
+  truncateDescription,
+  optimizeTool,
+};

--- a/src/gating/toolset-registry.ts
+++ b/src/gating/toolset-registry.ts
@@ -1,4 +1,5 @@
 import type { MCPTool } from '../utils/types.js';
+import { optimizeTool } from './schema-optimizer.js';
 
 export type ToolsetLoader = () => Promise<Record<string, MCPTool>>;
 
@@ -25,8 +26,11 @@ export class ToolGateController {
       return;
     }
     const tools = await loader();
-    this.toolsetTools[name] = Object.keys(tools);
-    Object.assign(this.loadedTools, tools);
+    const optimized = Object.fromEntries(
+      Object.entries(tools).map(([n, t]) => [n, optimizeTool(t)])
+    );
+    this.toolsetTools[name] = Object.keys(optimized);
+    Object.assign(this.loadedTools, optimized);
     this.activeToolsets.add(name);
   }
 

--- a/src/mcp/claude-flow-tools.ts
+++ b/src/mcp/claude-flow-tools.ts
@@ -4,6 +4,7 @@
 
 import type { MCPTool, MCPContext, AgentProfile, Task, MemoryEntry } from '../utils/types.js';
 import type { ILogger } from '../core/logger.js';
+import { optimizeTool } from '../gating/schema-optimizer.js';
 import { getValidAgentTypes as getAvailableAgentTypes, getAgentTypeSchema } from '../constants/agent-types.js';
 import type { Permissions } from './auth.js';
 
@@ -114,13 +115,13 @@ export async function createClaudeFlowTools(logger: ILogger): Promise<MCPTool[]>
     expanded.map((tool) => enhanceToolWithAgentTypes(tool))
   );
 
-  return enhancedTools;
+  return enhancedTools.map(optimizeTool);
 }
 
 export function createSpawnAgentTool(logger: ILogger): ClaudeFlowTool {
   return {
     name: 'agents/spawn',
-    description: 'Spawn a new Claude agent with specified configuration',
+    description: 'Spawn a Claude agent with settings',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -7,6 +7,7 @@
 import { createClaudeFlowTools } from './claude-flow-tools.js';
 import { memoryStore } from '../memory/fallback-store.js';
 import { ToolGateController } from '../gating/toolset-registry.js';
+import { optimizeTool } from '../gating/schema-optimizer.js';
 
 class ClaudeFlowMCPServer {
   constructor() {
@@ -37,7 +38,7 @@ class ClaudeFlowMCPServer {
 
   // Database operations now use the same memory store as working npx commands
   getDiscoveryTools() {
-    return {
+    const tools = {
       discover_toolsets: {
         name: 'discover_toolsets',
         description: 'List available toolsets',
@@ -79,6 +80,10 @@ class ClaudeFlowMCPServer {
         handler: async () => ({ tools: this.gateController.listActiveTools() }),
       },
     };
+    for (const key of Object.keys(tools)) {
+      tools[key] = optimizeTool(tools[key]);
+    }
+    return tools;
   }
 
   initializeTools() {

--- a/tests/unit/gating/schema-optimizer.test.ts
+++ b/tests/unit/gating/schema-optimizer.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from '../../test.utils';
+import { optimizeTool } from '../../../src/gating/schema-optimizer.ts';
+import type { MCPTool } from '../../../src/utils/types.ts';
+
+describe('schema optimizer', () => {
+  it('truncates descriptions and strips schema extras', () => {
+    const long = 'x'.repeat(60);
+    const tool: MCPTool = {
+      name: 'test/tool',
+      description: long,
+      inputSchema: {
+        type: 'object',
+        description: long,
+        properties: {
+          foo: {
+            type: 'string',
+            description: long,
+            default: 'bar',
+            examples: ['baz'],
+          },
+        },
+      },
+      handler: async () => ({})
+    };
+
+    const optimized = optimizeTool(tool);
+    expect(optimized.description.length).toBeLessThanOrEqual(50);
+    const schema: any = optimized.inputSchema;
+    expect(schema.description.length).toBeLessThanOrEqual(50);
+    const foo = schema.properties.foo;
+    expect(foo.default).toBeUndefined();
+    expect(foo.examples).toBeUndefined();
+    expect(foo.description.length).toBeLessThanOrEqual(50);
+  });
+});

--- a/tests/unit/gating/toolset-registry.test.ts
+++ b/tests/unit/gating/toolset-registry.test.ts
@@ -33,4 +33,35 @@ describe('ToolGateController', () => {
     const sizeAfter = controller.getContextSize();
     expect(sizeAfter).toBeLessThan(sizeWithBoth);
   });
+
+  it('optimizes tool schemas on registration', async () => {
+    const long = 'x'.repeat(60);
+    controller = new ToolGateController({
+      setC: async () => ({
+        tool: {
+          name: 'tool',
+          description: long,
+          inputSchema: {
+            type: 'object',
+            properties: {
+              foo: {
+                type: 'string',
+                description: long,
+                default: 'bar',
+                examples: ['baz']
+              }
+            }
+          },
+          handler: async () => ({})
+        }
+      })
+    });
+    await controller.enableToolset('setC');
+    const tool = controller.getAvailableTools()['tool'] as any;
+    expect(tool.description.length).toBeLessThanOrEqual(50);
+    const foo = tool.inputSchema.properties.foo;
+    expect(foo.default).toBeUndefined();
+    expect(foo.examples).toBeUndefined();
+    expect(foo.description.length).toBeLessThanOrEqual(50);
+  });
 });


### PR DESCRIPTION
## Summary
- add schema optimizer to trim descriptions and strip optional fields
- wire optimizer into gate controller, tool factory, and MCP server discovery tools
- add tests for schema optimization and registration

## Testing
- `npm test` *(fails: Verification Pipeline E2E Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba146670cc832abc72f840509bd7de