### PR TITLE
Refactor AgentLoader for lazy definition loading

### DIFF
--- a/src/mcp/claude-flow-tools.ts
+++ b/src/mcp/claude-flow-tools.ts
@@ -6,6 +6,7 @@ import type { MCPTool, MCPContext, AgentProfile, Task, MemoryEntry } from '../ut
 import type { ILogger } from '../core/logger.js';
 import { getValidAgentTypes as getAvailableAgentTypes, getAgentTypeSchema } from '../constants/agent-types.js';
 import type { Permissions } from './auth.js';
+import { getAgent as loadAgentDefinition } from '../agents/agent-loader.js';
 
 export interface ClaudeFlowToolContext extends MCPContext {
   orchestrator?: any; // Reference to orchestrator instance
@@ -171,12 +172,15 @@ export function createSpawnAgentTool(logger: ILogger): ClaudeFlowTool {
         throw new Error('Orchestrator not available');
       }
 
+      const definition = await loadAgentDefinition(input.type);
+
       const profile: AgentProfile = {
         id: `agent_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
         name: input.name,
         type: input.type,
-        capabilities: input.capabilities || [],
-        systemPrompt: input.systemPrompt || getDefaultSystemPrompt(input.type),
+        capabilities: input.capabilities || definition?.capabilities || [],
+        systemPrompt:
+          input.systemPrompt || definition?.content || getDefaultSystemPrompt(input.type),
         maxConcurrentTasks: input.maxConcurrentTasks || 3,
         priority: input.priority || 5,
         environment: input.environment,

--- a/src/mcp/mcp-server.js
+++ b/src/mcp/mcp-server.js
@@ -7,6 +7,7 @@
 import { createClaudeFlowTools } from './claude-flow-tools.js';
 import { memoryStore } from '../memory/fallback-store.js';
 import { ToolGateController } from '../gating/toolset-registry.js';
+import { getAgent as loadAgentDefinition, resolveLegacyAgentType } from '../agents/agent-loader.js';
 
 class ClaudeFlowMCPServer {
   constructor() {
@@ -1094,13 +1095,15 @@ class ClaudeFlowMCPServer {
       case 'agent_spawn':
         const agentId = `agent_${Date.now()}_${Math.random().toString(36).substr(2, 6)}`;
         const resolvedType = resolveLegacyAgentType(args.type);
+        const definition = await loadAgentDefinition(resolvedType);
+        const capabilities = args.capabilities || definition?.capabilities || [];
         const agentData = {
           id: agentId,
           swarmId: args.swarmId || (await this.getActiveSwarmId()),
           name: args.name || `${resolvedType}-${Date.now()}`,
           type: resolvedType,
           status: 'active',
-          capabilities: JSON.stringify(args.capabilities || []),
+          capabilities: JSON.stringify(capabilities),
           metadata: JSON.stringify({
             sessionId: this.sessionId,
             createdBy: 'mcp-server',

--- a/tests/perf/agent-loader.test.ts
+++ b/tests/perf/agent-loader.test.ts
@@ -1,0 +1,38 @@
+import { agentLoader } from '../../src/agents/agent-loader.js';
+import { performance } from 'node:perf_hooks';
+
+describe('AgentLoader performance', () => {
+  const agentName = 'researcher';
+
+  beforeEach(async () => {
+    await agentLoader.refresh();
+  });
+
+  test('lazy getAgent uses less memory than preloading all', async () => {
+    const beforeSingle = process.memoryUsage().heapUsed;
+    await agentLoader.getAgent(agentName);
+    const afterSingle = process.memoryUsage().heapUsed;
+    const singleDelta = afterSingle - beforeSingle;
+
+    await agentLoader.refresh();
+    const beforeAll = process.memoryUsage().heapUsed;
+    await agentLoader.preloadAgents();
+    const afterAll = process.memoryUsage().heapUsed;
+    const allDelta = afterAll - beforeAll;
+
+    expect(singleDelta).toBeLessThan(allDelta);
+  });
+
+  test('loading single agent is faster than preloading all', async () => {
+    let start = performance.now();
+    await agentLoader.getAgent(agentName);
+    const singleTime = performance.now() - start;
+
+    await agentLoader.refresh();
+    start = performance.now();
+    await agentLoader.preloadAgents();
+    const allTime = performance.now() - start;
+
+    expect(singleTime).toBeLessThan(allTime);
+  });
+});


### PR DESCRIPTION
## Summary
- load individual agent definitions on demand with new AgentLoader index and `preloadAgents`
- request agent definitions lazily in registry and spawn tools
- add performance benchmark for AgentLoader memory and speed

## Testing
- `npm test tests/perf/agent-loader.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ba14693838832ab682a8a4d882aa64