### PR TITLE
Add configurable tool gating filters

### DIFF
--- a/src/gating/filter-config.json
+++ b/src/gating/filter-config.json
@@ -1,0 +1,14 @@
+{
+  "taskType": {
+    "enabled": false,
+    "map": {}
+  },
+  "resource": {
+    "enabled": false,
+    "maxTools": 10
+  },
+  "security": {
+    "enabled": false,
+    "blocked": []
+  }
+}

--- a/src/gating/filters/ResourceFilter.ts
+++ b/src/gating/filters/ResourceFilter.ts
@@ -1,0 +1,18 @@
+import type { MCPTool } from '../../utils/types.js';
+import type { ToolFilter, FilterContext } from './types.js';
+
+interface ResourceFilterConfig {
+  enabled: boolean;
+  maxTools: number;
+}
+
+export class ResourceFilter implements ToolFilter {
+  constructor(private config: ResourceFilterConfig) {}
+
+  apply(tools: Record<string, MCPTool>, _context: FilterContext): Record<string, MCPTool> {
+    const max = this.config.maxTools;
+    const entries = Object.entries(tools);
+    if (!max || entries.length <= max) return tools;
+    return Object.fromEntries(entries.slice(0, max));
+  }
+}

--- a/src/gating/filters/SecurityFilter.ts
+++ b/src/gating/filters/SecurityFilter.ts
@@ -1,0 +1,20 @@
+import type { MCPTool } from '../../utils/types.js';
+import type { ToolFilter, FilterContext } from './types.js';
+
+interface SecurityFilterConfig {
+  enabled: boolean;
+  blocked: string[];
+}
+
+export class SecurityFilter implements ToolFilter {
+  constructor(private config: SecurityFilterConfig) {}
+
+  apply(tools: Record<string, MCPTool>, _context: FilterContext): Record<string, MCPTool> {
+    if (!this.config.blocked || this.config.blocked.length === 0) return tools;
+    const result = { ...tools };
+    for (const name of this.config.blocked) {
+      delete result[name];
+    }
+    return result;
+  }
+}

--- a/src/gating/filters/TaskTypeFilter.ts
+++ b/src/gating/filters/TaskTypeFilter.ts
@@ -1,0 +1,25 @@
+import type { MCPTool } from '../../utils/types.js';
+import type { ToolFilter, FilterContext } from './types.js';
+
+interface TaskTypeFilterConfig {
+  enabled: boolean;
+  map: Record<string, string[]>;
+}
+
+export class TaskTypeFilter implements ToolFilter {
+  constructor(private config: TaskTypeFilterConfig) {}
+
+  apply(tools: Record<string, MCPTool>, context: FilterContext): Record<string, MCPTool> {
+    const type = context.taskType;
+    if (!type) return tools;
+    const allowed = this.config.map?.[type];
+    if (!allowed || allowed.length === 0) return tools;
+    const result: Record<string, MCPTool> = {};
+    for (const name of allowed) {
+      if (tools[name]) {
+        result[name] = tools[name];
+      }
+    }
+    return result;
+  }
+}

--- a/src/gating/filters/types.ts
+++ b/src/gating/filters/types.ts
@@ -1,0 +1,10 @@
+import type { MCPTool } from '../../utils/types.js';
+
+export interface FilterContext {
+  taskType?: string;
+  [key: string]: unknown;
+}
+
+export interface ToolFilter {
+  apply(tools: Record<string, MCPTool>, context: FilterContext): Record<string, MCPTool>;
+}

--- a/src/gating/toolset-registry.ts
+++ b/src/gating/toolset-registry.ts
@@ -1,4 +1,9 @@
 import type { MCPTool } from '../utils/types.js';
+import { TaskTypeFilter } from './filters/TaskTypeFilter.js';
+import { ResourceFilter } from './filters/ResourceFilter.js';
+import { SecurityFilter } from './filters/SecurityFilter.js';
+import type { ToolFilter, FilterContext } from './filters/types.js';
+import filterConfigDefault from './filter-config.json' with { type: 'json' };
 
 export type ToolsetLoader = () => Promise<Record<string, MCPTool>>;
 
@@ -7,9 +12,22 @@ export class ToolGateController {
   private activeToolsets = new Set<string>();
   private loadedTools: Record<string, MCPTool> = {};
   private toolsetTools: Record<string, string[]> = {};
+  private filters: ToolFilter[] = [];
 
-  constructor(toolsetLoaders: Record<string, ToolsetLoader> = {}) {
+  constructor(
+    toolsetLoaders: Record<string, ToolsetLoader> = {},
+    filterConfig: typeof filterConfigDefault = filterConfigDefault
+  ) {
     this.toolsetLoaders = toolsetLoaders;
+    if (filterConfig.taskType?.enabled) {
+      this.filters.push(new TaskTypeFilter(filterConfig.taskType));
+    }
+    if (filterConfig.resource?.enabled) {
+      this.filters.push(new ResourceFilter(filterConfig.resource));
+    }
+    if (filterConfig.security?.enabled) {
+      this.filters.push(new SecurityFilter(filterConfig.security));
+    }
   }
 
   discoverToolsets(): string[] {
@@ -45,8 +63,12 @@ export class ToolGateController {
     return Object.keys(this.loadedTools);
   }
 
-  getAvailableTools(): Record<string, MCPTool> {
-    return { ...this.loadedTools };
+  getAvailableTools(context: FilterContext = {}): Record<string, MCPTool> {
+    let tools: Record<string, MCPTool> = { ...this.loadedTools };
+    for (const filter of this.filters) {
+      tools = filter.apply(tools, context);
+    }
+    return tools;
   }
 
   getContextSize(): number {

--- a/tests/unit/gating/filters.test.ts
+++ b/tests/unit/gating/filters.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from '../../test.utils';
+import { ToolGateController } from '../../../src/gating/toolset-registry.ts';
+import type { MCPTool } from '../../../src/utils/types.ts';
+
+const createTool = (name: string): MCPTool => ({
+  name,
+  description: name,
+  inputSchema: { type: 'object', properties: {} },
+  handler: async () => ({ ok: true })
+});
+
+const loader = async () => ({
+  a_tool: createTool('a_tool'),
+  b_tool: createTool('b_tool'),
+  c_tool: createTool('c_tool')
+});
+
+describe('Tool filters', () => {
+  beforeEach(() => {
+    // noop
+  });
+
+  it('filters by task type', async () => {
+    const controller = new ToolGateController({ set: loader }, {
+      taskType: { enabled: true, map: { typeA: ['a_tool'] } }
+    } as any);
+    await controller.enableToolset('set');
+    const tools = controller.getAvailableTools({ taskType: 'typeA' });
+    expect(Object.keys(tools)).toEqual(['a_tool']);
+  });
+
+  it('filters by security blocklist', async () => {
+    const controller = new ToolGateController({ set: loader }, {
+      security: { enabled: true, blocked: ['b_tool'] }
+    } as any);
+    await controller.enableToolset('set');
+    const tools = controller.getAvailableTools();
+    expect(Object.keys(tools)).toEqual(['a_tool', 'c_tool']);
+  });
+
+  it('limits number of tools via resource filter', async () => {
+    const controller = new ToolGateController({ set: loader }, {
+      resource: { enabled: true, maxTools: 2 }
+    } as any);
+    await controller.enableToolset('set');
+    const tools = controller.getAvailableTools();
+    expect(Object.keys(tools)).toEqual(['a_tool', 'b_tool']);
+  });
+
+  it('applies all filters in chain', async () => {
+    const controller = new ToolGateController({ set: loader }, {
+      taskType: { enabled: true, map: { typeB: ['b_tool', 'c_tool'] } },
+      resource: { enabled: true, maxTools: 2 },
+      security: { enabled: true, blocked: ['c_tool'] }
+    } as any);
+    await controller.enableToolset('set');
+    const tools = controller.getAvailableTools({ taskType: 'typeB' });
+    expect(Object.keys(tools)).toEqual(['b_tool']);
+  });
+});


### PR DESCRIPTION
## Summary
- add TaskTypeFilter, ResourceFilter, and SecurityFilter classes with shared interface
- plug filter chain into ToolGateController and load settings from new filter-config.json
- cover filtering scenarios with unit tests

## Testing
- `npm test tests/unit/gating`


------
https://chatgpt.com/codex/tasks/task_e_68ba146b1918832a821f84de55e7810b