### PR TITLE
fix import extension mismatch in tool gating tests

### DIFF
--- a/tests/unit/gating/filters.test.ts
+++ b/tests/unit/gating/filters.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from '../../test.utils';
-import { ToolGateController } from '../../../src/gating/toolset-registry.ts';
-import type { MCPTool } from '../../../src/utils/types.ts';
+import { ToolGateController } from '../../../src/gating/toolset-registry.js';
+import type { MCPTool } from '../../../src/utils/types.js';
 
 const createTool = (name: string): MCPTool => ({
   name,

--- a/tests/unit/gating/schema-optimizer.test.ts
+++ b/tests/unit/gating/schema-optimizer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '../../test.utils';
-import { optimizeTool } from '../../../src/gating/schema-optimizer.ts';
-import type { MCPTool } from '../../../src/utils/types.ts';
+import { optimizeTool } from '../../../src/gating/schema-optimizer.js';
+import type { MCPTool } from '../../../src/utils/types.js';
 
 describe('schema optimizer', () => {
   it('truncates descriptions and strips schema extras', () => {

--- a/tests/unit/gating/toolset-registry.test.ts
+++ b/tests/unit/gating/toolset-registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from '../../test.utils';
-import { ToolGateController } from '../../../src/gating/toolset-registry.ts';
-import type { MCPTool } from '../../../src/utils/types.ts';
+import { ToolGateController } from '../../../src/gating/toolset-registry.js';
+import type { MCPTool } from '../../../src/utils/types.js';
 
 const createTool = (name: string): MCPTool => ({
   name,


### PR DESCRIPTION
## Summary
- fix import paths in gating unit tests to use `.js` extensions
- ensure gating tests run under Node's ESM

## Testing
- `npm test tests/unit/gating`


------
https://chatgpt.com/codex/tasks/task_e_68bcb426f8f4832a9d0705269903f923