### PR TITLE
feat: Auto-Disable with TTL/LRU eviction to reduce context bloat (#14)

### DIFF
--- a/src/gating/filter-config.json
+++ b/src/gating/filter-config.json
@@ -10,5 +10,7 @@
   "security": {
     "enabled": false,
     "blocked": []
-  }
+  },
+  "autoDisableTtlMs": 300000,
+  "maxActiveToolsets": 0
 }

--- a/src/gating/toolset-registry.ts
+++ b/src/gating/toolset-registry.ts
@@ -15,12 +15,25 @@ export class ToolGateController {
   private loadedTools: Record<string, MCPTool> = {};
   private toolsetTools: Record<string, string[]> = {};
   private filters: ToolFilter[] = [];
+  
+  // NEW: TTL/LRU tracking
+  private toolsetLastUsed = new Map<string, number>();
+  private toolNameToToolset = new Map<string, string>();
+  private pinned = new Set<string>();
+  private ttlMs: number = 5 * 60_000; // default 5 minutes
+  private maxActiveToolsets: number = 0; // 0 = unlimited
 
   constructor(
     toolsetLoaders: Record<string, ToolsetLoader> = {},
     filterConfig: typeof filterConfigDefault = filterConfigDefault
   ) {
     this.toolsetLoaders = toolsetLoaders;
+    
+    // Initialize TTL/LRU configuration
+    this.ttlMs = (filterConfig as any).autoDisableTtlMs ?? this.ttlMs;
+    this.maxActiveToolsets = (filterConfig as any).maxActiveToolsets ?? 0;
+    
+    // Initialize filters
     if (filterConfig.taskType?.enabled) {
       this.filters.push(new TaskTypeFilter(filterConfig.taskType));
     }
@@ -49,8 +62,20 @@ export class ToolGateController {
       Object.entries(tools).map(([n, t]) => [n, optimizeTool(t)])
     );
     this.toolsetTools[name] = Object.keys(optimized);
+    
+    // Track tool-to-toolset mapping for usage tracking
+    for (const toolName of Object.keys(optimized)) {
+      this.toolNameToToolset.set(toolName, name);
+    }
+    
     Object.assign(this.loadedTools, optimized);
     this.activeToolsets.add(name);
+    
+    // Mark as recently used
+    this.toolsetLastUsed.set(name, Date.now());
+    
+    // Enforce LRU cap after enabling
+    this.enforceLRUCap();
   }
 
   disableToolset(name: string): void {
@@ -59,9 +84,107 @@ export class ToolGateController {
     }
     for (const toolName of this.toolsetTools[name] || []) {
       delete this.loadedTools[toolName];
+      this.toolNameToToolset.delete(toolName);
     }
     delete this.toolsetTools[name];
     this.activeToolsets.delete(name);
+    this.toolsetLastUsed.delete(name);
+  }
+  
+  /**
+   * Mark a tool as recently used (updates toolset timestamp)
+   */
+  markUsed(toolName: string): void {
+    const setName = this.toolNameToToolset.get(toolName);
+    if (setName && this.activeToolsets.has(setName)) {
+      this.toolsetLastUsed.set(setName, Date.now());
+    }
+  }
+  
+  /**
+   * Sweep and disable expired toolsets based on TTL
+   */
+  sweepExpiredToolsets(): string[] {
+    const now = Date.now();
+    const disabled: string[] = [];
+    
+    for (const [setName, lastUsed] of this.toolsetLastUsed) {
+      if (!this.activeToolsets.has(setName)) continue;
+      if (this.pinned.has(setName)) continue;
+      
+      if (now - lastUsed > this.ttlMs) {
+        this.disableToolset(setName);
+        disabled.push(setName);
+        console.log(`[Auto-Disable] Toolset "${setName}" disabled due to TTL expiry`);
+      }
+    }
+    
+    return disabled;
+  }
+  
+  /**
+   * Enforce LRU cap by disabling least recently used toolsets
+   */
+  enforceLRUCap(): string[] {
+    if (!this.maxActiveToolsets || this.activeToolsets.size <= this.maxActiveToolsets) {
+      return [];
+    }
+    
+    // Get unpinned candidates sorted by last use time (oldest first)
+    const candidates = [...this.activeToolsets]
+      .filter(s => !this.pinned.has(s))
+      .sort((a, b) => (this.toolsetLastUsed.get(a) ?? 0) - (this.toolsetLastUsed.get(b) ?? 0));
+    
+    const toDisable: string[] = [];
+    const excessCount = this.activeToolsets.size - this.maxActiveToolsets;
+    
+    for (let i = 0; i < excessCount && i < candidates.length; i++) {
+      const victim = candidates[i];
+      this.disableToolset(victim);
+      toDisable.push(victim);
+      console.log(`[Auto-Disable] Toolset "${victim}" disabled due to LRU cap`);
+    }
+    
+    return toDisable;
+  }
+  
+  /**
+   * Pin a toolset to prevent auto-disable
+   */
+  pinToolset(name: string): void {
+    this.pinned.add(name);
+    console.log(`[Pin] Toolset "${name}" pinned`);
+  }
+  
+  /**
+   * Unpin a toolset to allow auto-disable
+   */
+  unpinToolset(name: string): void {
+    this.pinned.delete(name);
+    console.log(`[Unpin] Toolset "${name}" unpinned`);
+  }
+  
+  /**
+   * Get list of pinned toolsets
+   */
+  getPinnedToolsets(): string[] {
+    return Array.from(this.pinned);
+  }
+  
+  /**
+   * Get usage statistics for monitoring
+   */
+  getUsageStats(): Record<string, { lastUsed: number; pinned: boolean }> {
+    const stats: Record<string, { lastUsed: number; pinned: boolean }> = {};
+    
+    for (const setName of this.activeToolsets) {
+      stats[setName] = {
+        lastUsed: this.toolsetLastUsed.get(setName) ?? 0,
+        pinned: this.pinned.has(setName)
+      };
+    }
+    
+    return stats;
   }
 
   listActiveTools(): string[] {

--- a/tests/unit/gating/eviction.test.ts
+++ b/tests/unit/gating/eviction.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { ToolGateController } from '../../../src/gating/toolset-registry.js';
+import type { MCPTool } from '../../../src/utils/types.js';
+
+describe('TTL/LRU Eviction', () => {
+  let controller: ToolGateController;
+  let mockTools: Record<string, MCPTool>;
+
+  beforeEach(() => {
+    // Create mock tools
+    mockTools = {
+      'test-tool': {
+        name: 'test-tool',
+        description: 'A test tool',
+        inputSchema: { type: 'object' },
+        handler: async () => ({ result: 'test' })
+      }
+    };
+
+    // Create mock loaders
+    const loaders = {
+      toolset1: async () => ({ ...mockTools }),
+      toolset2: async () => ({ 'tool2': { ...mockTools['test-tool'], name: 'tool2' } }),
+      toolset3: async () => ({ 'tool3': { ...mockTools['test-tool'], name: 'tool3' } }),
+      toolset4: async () => ({ 'tool4': { ...mockTools['test-tool'], name: 'tool4' } })
+    };
+
+    // Create controller with short TTL for testing
+    controller = new ToolGateController(loaders, {
+      taskType: { enabled: false, map: {} },
+      resource: { enabled: false, maxTools: 10 },
+      security: { enabled: false, blocked: [] },
+      autoDisableTtlMs: 1000, // 1 second for testing
+      maxActiveToolsets: 3 // Cap at 3 for testing
+    } as any);
+  });
+
+  describe('TTL Expiration', () => {
+    it('should disable toolsets after TTL expires', async () => {
+      // Enable a toolset
+      await controller.enableToolset('toolset1');
+      expect(controller.listActiveTools()).toContain('test-tool');
+
+      // Mark as used
+      controller.markUsed('test-tool');
+
+      // Wait for TTL to expire
+      await new Promise(resolve => setTimeout(resolve, 1100));
+
+      // Sweep expired toolsets
+      const disabled = controller.sweepExpiredToolsets();
+      expect(disabled).toContain('toolset1');
+      expect(controller.listActiveTools()).not.toContain('test-tool');
+    });
+
+    it('should not disable pinned toolsets after TTL', async () => {
+      // Enable and pin a toolset
+      await controller.enableToolset('toolset1');
+      controller.pinToolset('toolset1');
+
+      // Wait for TTL to expire
+      await new Promise(resolve => setTimeout(resolve, 1100));
+
+      // Sweep expired toolsets
+      const disabled = controller.sweepExpiredToolsets();
+      expect(disabled).not.toContain('toolset1');
+      expect(controller.listActiveTools()).toContain('test-tool');
+    });
+
+    it('should update last used time when tool is called', async () => {
+      await controller.enableToolset('toolset1');
+      
+      // Wait half the TTL
+      await new Promise(resolve => setTimeout(resolve, 600));
+      
+      // Mark as used (refreshes TTL)
+      controller.markUsed('test-tool');
+      
+      // Wait another 600ms (would expire without refresh)
+      await new Promise(resolve => setTimeout(resolve, 600));
+      
+      // Should still be active
+      const disabled = controller.sweepExpiredToolsets();
+      expect(disabled).not.toContain('toolset1');
+      expect(controller.listActiveTools()).toContain('test-tool');
+    });
+  });
+
+  describe('LRU Cap', () => {
+    it('should evict least recently used toolsets when cap is exceeded', async () => {
+      // Enable toolsets up to cap
+      await controller.enableToolset('toolset1');
+      await new Promise(resolve => setTimeout(resolve, 10));
+      await controller.enableToolset('toolset2');
+      await new Promise(resolve => setTimeout(resolve, 10));
+      await controller.enableToolset('toolset3');
+      
+      // All should be active
+      expect(controller.listActiveTools()).toHaveLength(3);
+      
+      // Enable one more (exceeds cap)
+      await controller.enableToolset('toolset4');
+      
+      // toolset1 should be evicted (oldest)
+      expect(controller.listActiveTools()).toHaveLength(3);
+      expect(controller.listActiveTools()).toContain('tool2');
+      expect(controller.listActiveTools()).toContain('tool3');
+      expect(controller.listActiveTools()).toContain('tool4');
+      expect(controller.listActiveTools()).not.toContain('test-tool');
+    });
+
+    it('should not evict pinned toolsets for LRU', async () => {
+      // Enable and pin first toolset
+      await controller.enableToolset('toolset1');
+      controller.pinToolset('toolset1');
+      
+      await controller.enableToolset('toolset2');
+      await controller.enableToolset('toolset3');
+      
+      // Enable one more (exceeds cap)
+      await controller.enableToolset('toolset4');
+      
+      // toolset2 should be evicted (oldest unpinned)
+      expect(controller.listActiveTools()).toContain('test-tool'); // from pinned toolset1
+      expect(controller.listActiveTools()).not.toContain('tool2'); // evicted
+      expect(controller.listActiveTools()).toContain('tool3');
+      expect(controller.listActiveTools()).toContain('tool4');
+    });
+
+    it('should update LRU order when tools are used', async () => {
+      await controller.enableToolset('toolset1');
+      await controller.enableToolset('toolset2');
+      await controller.enableToolset('toolset3');
+      
+      // Use toolset1 to make it most recent
+      controller.markUsed('test-tool');
+      
+      // Enable one more
+      await controller.enableToolset('toolset4');
+      
+      // toolset2 should be evicted (now oldest)
+      expect(controller.listActiveTools()).toContain('test-tool'); // recently used
+      expect(controller.listActiveTools()).not.toContain('tool2'); // evicted
+      expect(controller.listActiveTools()).toContain('tool3');
+      expect(controller.listActiveTools()).toContain('tool4');
+    });
+  });
+
+  describe('Pin/Unpin', () => {
+    it('should pin and unpin toolsets', async () => {
+      await controller.enableToolset('toolset1');
+      
+      // Pin the toolset
+      controller.pinToolset('toolset1');
+      expect(controller.getPinnedToolsets()).toContain('toolset1');
+      
+      // Unpin the toolset
+      controller.unpinToolset('toolset1');
+      expect(controller.getPinnedToolsets()).not.toContain('toolset1');
+    });
+
+    it('should return usage statistics', async () => {
+      await controller.enableToolset('toolset1');
+      controller.pinToolset('toolset1');
+      await controller.enableToolset('toolset2');
+      
+      const stats = controller.getUsageStats();
+      
+      expect(stats['toolset1']).toBeDefined();
+      expect(stats['toolset1'].pinned).toBe(true);
+      expect(stats['toolset1'].lastUsed).toBeGreaterThan(0);
+      
+      expect(stats['toolset2']).toBeDefined();
+      expect(stats['toolset2'].pinned).toBe(false);
+      expect(stats['toolset2'].lastUsed).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Implements Issue #14: Auto-Disable (TTL/LRU Eviction)

This PR adds automatic toolset eviction to prevent context window bloat from inactive tools. Once enabled, toolsets now automatically disappear after inactivity (TTL) or when memory limits are reached (LRU).

## What's Implemented

### TTL (Time To Live) Expiration
- Toolsets automatically disable after configurable idle time
- Default TTL: 5 minutes (configurable via autoDisableTtlMs)
- Usage tracking via markUsed() updates timestamps
- Pinned toolsets are exempt from TTL expiration

### LRU (Least Recently Used) Cap
- Optional maximum limit on concurrent active toolsets
- When cap is exceeded, least recently used toolsets are evicted
- Pinned toolsets are protected from LRU eviction
- Maintains optimal context window size

### Pin/Unpin Mechanism
- Pin important toolsets for long-running work
- Pinned toolsets never expire or get evicted
- Simple API: pinToolset() and unpinToolset()
- Track pinned status via getPinnedToolsets()

### Usage Tracking & Statistics
- markUsed() method updates toolset activity
- getUsageStats() provides monitoring data
- Tracks last used timestamp and pin status
- Useful for debugging and optimization

## Configuration

Added to filter-config.json:
- autoDisableTtlMs: 300000 (5 minutes default)
- maxActiveToolsets: 0 (0 = unlimited, set to cap active toolsets)

## API Additions

New methods in ToolGateController:
- markUsed(toolName): Update usage timestamp
- sweepExpiredToolsets(): Remove TTL-expired toolsets
- enforceLRUCap(): Enforce maximum toolset limit
- pinToolset(name): Protect from auto-disable
- unpinToolset(name): Allow auto-disable
- getPinnedToolsets(): List pinned toolsets
- getUsageStats(): Get usage monitoring data

## Performance Impact
- Reduces context window size by removing inactive tools
- Prevents unbounded growth of loaded toolsets
- Maintains working set of actively used tools
- Zero overhead when within limits

## Testing
Comprehensive test suite in tests/unit/gating/eviction.test.ts:
- TTL expiration with configurable timeouts
- LRU eviction when cap is exceeded
- Pin/unpin protection mechanisms
- Usage tracking and statistics

## Integration Notes
Server integration should:
1. Call markUsed() on each tools/call
2. Periodically call sweepExpiredToolsets()
3. Call enforceLRUCap() after enabling toolsets
4. Emit tools.listChanged after evictions

Fixes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Automatic inactivity timeout for toolsets (default 5 minutes), with configurable duration.
  * Optional cap on concurrently active toolsets; least‑recently‑used sets auto‑evict when over the limit.
  * Ability to pin toolsets to prevent auto‑disable.
  * View usage stats, including last-used times and pinned status.
  * New configuration options to control auto-disable TTL and maximum active toolsets.

* Tests
  * Added unit tests covering TTL expiration, pin/unpin behavior, LRU-based eviction, and usage statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->